### PR TITLE
2 fix race conditions in java version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
         "goombler",
         "goomblers"
     ],
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/Java/app/build.gradle
+++ b/Java/app/build.gradle
@@ -33,3 +33,11 @@ tasks.named('test') {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
+
+jar {
+  manifest {
+    attributes(
+      'Main-Class': 'goomble.GoombleSimulation'
+    )
+  }
+}

--- a/Java/app/src/main/java/goomble/GoombleAccount.java
+++ b/Java/app/src/main/java/goomble/GoombleAccount.java
@@ -1,15 +1,23 @@
 package goomble;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class GoombleAccount {
 
-    private int balance;
+    private int balance = 0;
+    private AtomicInteger atomicBalance = new AtomicInteger(0);
 
     public void increment() {
         ++balance;
+        atomicBalance.incrementAndGet();
     }
 
     public int getBalance() {
         return balance;
+    }
+
+    public int getAtomicBalance() {
+        return atomicBalance.get();
     }
 
 }

--- a/Java/app/src/main/java/goomble/GoombleSimulation.java
+++ b/Java/app/src/main/java/goomble/GoombleSimulation.java
@@ -10,25 +10,28 @@ import java.util.concurrent.TimeUnit;
 
 public class GoombleSimulation {
 
+    public static boolean useLocks = false;
     private Random rand = new Random();
     private static final int MAX_BALANCE = 100;
     private Goombler[] goomblers;
     private GoombleAccount goombleAccount = new GoombleAccount();
     private int initialGoomblersTotalBalance = 0;
 
-    public GoombleSimulation(int numGamblers, int numRegions) {
+    public GoombleSimulation(int numGamblers) {
         goomblers = new Goombler[numGamblers];
         for (int i=0; i<numGamblers; ++i) {
-            goomblers[i] = new Goombler(goombleAccount, rand.nextInt(numRegions), rand.nextInt(MAX_BALANCE));
+            goomblers[i] = new Goombler(goombleAccount, rand.nextInt(MAX_BALANCE));
             initialGoomblersTotalBalance += goomblers[i].getBalance();
         }
     }
 
     public static void main(String[] args) throws InterruptedException {
+        if (args.length > 0 && args[0].equals("--lock")) {
+            useLocks = true;
+        }
         final int numGamblers = 12;
-        final int numRegions = 4;
         final int numPresses = numGamblers * MAX_BALANCE;
-        GoombleSimulation simulation = new GoombleSimulation(numGamblers, numRegions);
+        GoombleSimulation simulation = new GoombleSimulation(numGamblers);
         simulation.runSimulation(numPresses);
         simulation.printResults();
     }
@@ -54,6 +57,7 @@ public class GoombleSimulation {
             totalBalance += balance;
         }
         System.out.println("The total Goomblers balance is $" + totalBalance);
-        System.out.println("The Goomble Balance is $" + goombleAccount.getBalance());
+        System.out.println("The Goomble balance is $" + goombleAccount.getBalance());
+        System.out.println("The atomic Goomble balance is $" + goombleAccount.getAtomicBalance());
     }
 }

--- a/Java/app/src/main/java/goomble/Goombler.java
+++ b/Java/app/src/main/java/goomble/Goombler.java
@@ -1,7 +1,6 @@
 package goomble;
 
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class Goombler {

--- a/Java/app/src/main/java/goomble/Goombler.java
+++ b/Java/app/src/main/java/goomble/Goombler.java
@@ -2,18 +2,17 @@ package goomble;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class Goombler {
 
-    // DON'T WANT THE REGION NUMBER; WANT A REGION COUNTER OBJECT!
-    private int regionNumber;
     private int balance;
     private Random rand = new Random();
     private GoombleAccount goombleAccount;
+    private ReentrantLock lock = new ReentrantLock();
 
-    public Goombler(GoombleAccount goombleAccount, int regionNumber, int initialBalance) {
+    public Goombler(GoombleAccount goombleAccount, int initialBalance) {
         this.goombleAccount = goombleAccount;
-        this.regionNumber = regionNumber;
         this.balance = initialBalance;
     }
 
@@ -22,6 +21,9 @@ public class Goombler {
     }
 
     public void lucky() {
+        if (GoombleSimulation.useLocks) {
+            lock.lock();
+        }
         if (balance > 0) {
             // Sleeping for a small, random amount of time here makes it more likely that
             // two or more threads will interleave here in interesting ways, thus creating
@@ -29,11 +31,13 @@ public class Goombler {
             try {
                 Thread.sleep(rand.nextInt(60));
             } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
             --balance;
             goombleAccount.increment();
+        }
+        if (GoombleSimulation.useLocks) {
+            lock.unlock();
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # goomble-examples
 Several implementations of the key logic of the Goomble problem set from Saltzer &amp; Kaashoek's "Principles of Computer System Design"
+
+## Java version
+
+To do anything with the Java version, make sure you first go into the
+`Java` directory:
+
+```
+cd Java
+```
+
+### Building
+
+To build and run the java version, one of the easier ways is to use
+
+```text
+./gradlew jar
+```
+
+to build a standalone JAR file which you can then run with or
+without locks:
+
+```text
+java -jar app/build/libs/app.jar
+java -jar app/build/libs/app.jar --lock
+```
+
+If you precede either of this with `time` then the system will report
+some timing information:
+
+```text
+time java -jar app/build/libs/app.jar
+time java -jar app/build/libs/app.jar --lock
+```


### PR DESCRIPTION
This adds locks to Goombler.java that prevent the per-goombler race condition.

This still leaves us open to a race condition in the "global" GoombleAccount balance because multiple threads acting on different goomblers can run into each other in the global balance. I added an `AtomicInteger` to `GoombleAccount` to highlight the differences.

I also removed all the references to the ultimately unused region numbers.

Additionally, this sets up Gradle so that it creates a standalone JAR file that we can use to run (and more conveniently) time the system.

I also documented the building and running in the README.

Closes #2 