### PR TITLE
Removed threading on sends

### DIFF
--- a/Rust/goomble-channels/src/main.rs
+++ b/Rust/goomble-channels/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
 
     for goombler in goomblers {
         let (tx, rx) = channel_map.get(&goombler).unwrap();
-        thread_pool.execute(|| {
+        thread_pool.execute(move|| {
             for received in rx {
                 lucky(&goombler);
             }
@@ -87,12 +87,7 @@ fn main() {
         // let goomble_balance = Arc::clone(&goomble_balance);
         let goombler = goomblers.choose(&mut rand::thread_rng()).unwrap();
         let (tx, rx) = channel_map.get(goombler).unwrap();
-        let tx = tx.clone();
-        thread_pool.execute(move|| {
-            tx.send(String::from("push")).unwrap();
-            // lucky(goombler);
-            // lucky(goombler, goomble_balance);
-        });
+        tx.send(String::from("push")).unwrap();
     }
 
     // let tx1 = tx.clone();


### PR DESCRIPTION
I don't think I need to create a bazillion threads to *send* the push messages, especially since `tx.send()` will hopefully return quite quickly after stuffing the message onto the relevant channel.

This still doesn't compile and run – I've got some sort of problem on with sharing the receivers. I think receivers aren't meant to be shared across threads, and that I really need to figure out how to avoid trying to copy them.

Maybe I should construct all the receivers in the receiving threads, and somehow pass the senders out of those? I'm really not sure.